### PR TITLE
Cleaner markdownified readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
+[![BigTime Watch Kit](https://dlnmh9ip6v2uc.cloudfront.net/images/products/1/1/1/7/8/Watch-01-Working\(Pathed\)_medium.jpg)  
+*BigTime Watch Kit (KIT-11178)*](https://www.sparkfun.com/products/11178)
+
 BigTime is an open source hardware kit that allows the user to build their own watch.
 
-The hardware design is released under CC-SA v3 license.
+Hardware License
+================
+
+The hardware design is released under [CC-SA v3 license](http://creativecommons.org/licenses/by-sa/3.0/us/).
+
+Firmware License
+================
+
 The firmware is released under a modified beerware license.
 
 This project is forked with permission from Spikenzie labs' Solder:Time kit that is not open source. We really wanted to make the watch kits easier to hack so we combine the two ICs (a PIC and an RTC) into one (the ATmega328). We also rewrote all the code in C/Arduino so that it is easier to maintain and hack. We also reduced the current consumption so that you should get an estimated 2 years of run time on a single CR2032 cell!
+
+Version History
+===============
 
 v1.0 Initial code release 7-17-2011
 v1.1 Added rough support for other display colors 8-19-2011


### PR DESCRIPTION
# Experimental: Readme Cleanup Example

@mhord - here's a sample branch to demonstrate the type of README cleanup I'd like to do across several other of SparkFun's public branches. Changes:
- Ported from a text file to a *.md file
- Added product image, sku, and name that link to the product on sparkfun.com
- Put headers on the three main sections (two license sections and version history - I opted not to put a header up top as the image serves as an excellent header itself)
- Linked to license info where applicable

No README content has changed.

Do these changes seem about right? Helpful or nuisance? Also, is pushing a branch directly to the repo and issuing a pull req from there (as opposed to form a fork) a good way to go about it?
